### PR TITLE
fix something

### DIFF
--- a/src/ng-tiny-scrollbar.js
+++ b/src/ng-tiny-scrollbar.js
@@ -29,7 +29,7 @@ angular.module('ngTinyScrollbar', [])
         return {
             restrict: 'A',
             transclude: true,
-            template: '<div class="scroll-bar"><div class="scroll-thumb"></div></div><div class="scroll-viewport"><div class="scroll-overview" ng-transclude></div></div>',
+            template: '<div class="scroll-viewport"><div class="scroll-overview" ng-transclude></div></div><div class="scroll-bar"><div class="scroll-thumb"></div></div>',
             controller: function($scope, $element, $attrs) {
 
                 var defaults = {


### PR DESCRIPTION
commit-1 :  when you use JQuery before angular, the wheel event will be replaced by JQuery event, so we shoud access native event by using  event.originalEvent.

commit-2 :  the sub-element will inherit "no-select" from parent(body)

commit-3 :  when the width of "scroll-viewport" is as big as his parent-element, we can not click "scroll-bar", so I put "scroll-bar" after "scroll-viewport"
