### PR TITLE
MutationObserver - fix for dynamic content update

### DIFF
--- a/src/ng-tiny-scrollbar.js
+++ b/src/ng-tiny-scrollbar.js
@@ -153,6 +153,18 @@ angular.module('ngTinyScrollbar', [])
                     if(self.options.wheel) {
                         $element.on(wheelEvent, wheel);
                     }
+
+                    // check DOM content update
+                    var observer = new MutationObserver(function (mutations) {
+                        self.update();
+                    });
+
+                    observer.observe($element[0], {
+                        childList: true,
+                        subtree: true,
+                        characterData: true,
+                        attributes: true
+                    });
                 }
 
                 function resize() {


### PR DESCRIPTION
Added dynamic content change event. On DOM content change, using HTML5 Mutation Observer, ngTinyScrollbar fires the update method for scrollbar recalculation 

Works with IE11+, FF, Chrome, Opera, Safari
http://caniuse.com/#feat=mutationobserver

Hope that helps :)