### PR TITLE
MutationObserver optimization

### DIFF
--- a/src/ng-tiny-scrollbar.js
+++ b/src/ng-tiny-scrollbar.js
@@ -154,17 +154,32 @@ angular.module('ngTinyScrollbar', [])
                     }
 
                     if (self.options.autoUpdate && MutationObserver) {
-                        // check DOM content update
-                        var observer = new MutationObserver(function (mutations) {
-                            self.update();
-                        });
+                        (function () {
+                            var recentWidth = $overview[0].offsetWidth,
+                                recentHeight = $overview[0].offsetHeight,
+                                updateTimer;
 
-                        observer.observe($element[0], {
-                            childList: true,
-                            subtree: true,
-                            characterData: true,
-                            attributes: true
-                        });
+                            // check DOM content update
+                            var observer = new MutationObserver(function (mutations) {
+                                // Render scrollbar only with $overview dimension changes, once per digest cycle
+                                if (recentWidth !== $overview[0].offsetWidth ||
+                                    recentHeight !== $overview[0].offsetHeight) {
+                                    $timeout.cancel(updateTimer);
+                                    updateTimer = $timeout(function () {
+                                        recentWidth = $overview[0].offsetWidth;
+                                        recentHeight = $overview[0].offsetHeight;
+                                        self.update();
+                                    });
+                                }
+                            });
+
+                            observer.observe($element[0], {
+                                childList: true,
+                                subtree: true,
+                                characterData: true,
+                                attributes: true
+                            });
+                        })();
                     }
                 }
 


### PR DESCRIPTION
Hey, I added limitations of firing scrollbar update process with MutationObserver. Update will be called only if $overview element dimensions change and once per digest.

Previously the mutation process performed constantly, causing the browser to crash.